### PR TITLE
Revert "Revert "[Hotfix] 서버 에러 알림 모달 제거""

### DIFF
--- a/apps/web/src/app/join/Join.tsx
+++ b/apps/web/src/app/join/Join.tsx
@@ -5,14 +5,13 @@ import * as styles from './page.css';
 import InsteadLogoImage from '@web/assets/images/instead.svg';
 import { Spacing } from '@repo/ui/Spacing';
 import JoinImage from '@web/assets/images/join.png';
-import { useToast, useModal } from '@repo/ui/hooks';
+import { useToast } from '@repo/ui/hooks';
 import { useEffect } from 'react';
 import { Text } from '@repo/ui/Text';
 import { GoogleLoginButton } from './_components/GoogleLoginButton/GoogleLoginButton';
 
 export default function JoinPage() {
   const toast = useToast();
-  const modal = useModal();
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -22,15 +21,9 @@ export default function JoinPage() {
   }, [toast]);
 
   const handleGoogleLogin = async () => {
-    //window.location.href = process.env.NEXT_PUBLIC_GOOGLE_AUTH_URL ?? '';
-    modal.alert({
-      title: '서버 점검 중',
-      description:
-        '5/30(금) 오전 1시에 완료될 예정이에요\n이용에 불편을 드려 죄송해요',
-      alertButton: '확인',
-      isCloseOnDimmerClick: false,
-    });
+    window.location.href = process.env.NEXT_PUBLIC_GOOGLE_AUTH_URL ?? '';
   };
+
   return (
     <div className={styles.wrapper}>
       <Image


### PR DESCRIPTION
Reverts YAPP-Github/Instead-FE#195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 구글 로그인 시 서버 점검 알림 모달이 더 이상 표시되지 않고, 바로 구글 인증 페이지로 리다이렉트됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->